### PR TITLE
prevent autopublish

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,9 @@ make script ENV=.sm.env CMD=transfer_pinboards.js ACTION=rollback
 make script ENV=.global.env CMD=transfer_pinboards.js ACTION=rollback
 ```
 
+Manually check for duplicate `owner, title` pairs in the `pinboards` table
+and ensure to solve those conflicts. Then recreate the `unique_pinboard_owner`
+constraint using the version in `init.sql`.
 To finalize the changes and making it irreversible run:
 
 ```

--- a/README.md
+++ b/README.md
@@ -134,7 +134,17 @@ make script ENV=.global.env CMD=transfer_pinboards.js ACTION=rollback
 
 Manually check for duplicate `owner, title` pairs in the `pinboards` table
 and ensure to solve those conflicts. Then recreate the `unique_pinboard_owner`
-constraint using the version in `init.sql`.
+constraint using the version in `init.sql`. You can find those duplicates via:
+```
+SELECT t.owner, t.title, t.count FROM (
+    SELECT owner, title, COUNT(*) count FROM pinboards GROUP BY owner, title
+) as t WHERE t.count > 1
+```
+Once the duplicates are dealt with (e.g., by renaming) run:
+```
+ALTER TABLE pinboards DROP CONSTRAINT IF EXISTS unique_pinboard_owner;
+ALTER TABLE pinboards ADD CONSTRAINT unique_pinboard_owner UNIQUE (title, owner);
+```
 To finalize the changes and making it irreversible run:
 
 ```

--- a/app.js
+++ b/app.js
@@ -194,7 +194,7 @@ app.route('/apis/:action/:object')
 
 app.get('/api/skills', routes.api.skills) // TO DO: THIS SHOULD BE DEPRECATED
 app.get('/api/methods', routes.api.methods) // TO DO: THIS SHOULD BE DEPRECATED
-app.route('/api/datasources')
+app.route('/api/datasources') // TO DO: THIS SHOULD BE DEPRECATED
 	.get(routes.api.datasources)
 	.post(routes.api.datasources)
 

--- a/config/edit/index.js
+++ b/config/edit/index.js
@@ -7,6 +7,12 @@ if (app_id === 'ap') {
 	app_obj = {...app_obj, ...require('./exp.js')};
 } else if (app_id === 'sm') {
 	app_obj = {...app_obj, ...require('./sm.js')};
+} else if (app_id === 'global') {
+	app_obj = {
+		...app_obj,
+		app_title: 'DO NOT USE!',
+		app_title_short: 'ERROR!',
+	};
 } else if (app_id !== 'local') {
 	throw new Error(`APP_ID must be set to a valid value, got '${app_id}'`)
 }

--- a/init.sql
+++ b/init.sql
@@ -192,7 +192,7 @@ CREATE TABLE pinboards (
 	mobilization_db INT REFERENCES extern_db(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	mobilization INT  -- THIS IS TO CONNECT A PINBOARD DIRECTLY TO A MOBILIZATION
 );
-ALTER TABLE pinboards ADD CONSTRAINT unique_pinboard_owner UNIQUE (title, owner);
+ALTER TABLE pinboards ADD CONSTRAINT unique_pinboard_owner UNIQUE (title, owner, old_db);
 
 CREATE TABLE pinboard_contributors (
 	participant uuid NOT NULL,

--- a/init.sql
+++ b/init.sql
@@ -192,7 +192,10 @@ CREATE TABLE pinboards (
 	mobilization_db INT REFERENCES extern_db(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	mobilization INT  -- THIS IS TO CONNECT A PINBOARD DIRECTLY TO A MOBILIZATION
 );
+-- for migrating
 ALTER TABLE pinboards ADD CONSTRAINT unique_pinboard_owner UNIQUE (title, owner, old_db);
+ALTER TABLE pinboards DROP CONSTRAINT IF EXISTS unique_pinboard_owner;
+ALTER TABLE pinboards ADD CONSTRAINT unique_pinboard_owner UNIQUE (title, owner);
 
 CREATE TABLE pinboard_contributors (
 	participant uuid NOT NULL,

--- a/routes/engage/pin/pad.js
+++ b/routes/engage/pin/pad.js
@@ -159,7 +159,7 @@ async function updatestatus(_id, _object_id, _mobilization, uuid, ownId) {
 			WHERE pc.db = $2 AND pc.pinboard = $1 AND pb.owner = $3
 		`, [ _id, ownId, uuid ])).map((row) => row.pad);
 		const status = await DB.conn.any(`
-			SELECT GREATEST(1, COALESCE(MIN(p.status), 0)) as status
+			SELECT LEAST(1, GREATEST(1, COALESCE(MIN(p.status), 0))) as status
 			FROM pads p
 			WHERE p.id IN ($1:csv)
 		`, [ safeArr(pads, -1) ]);

--- a/routes/index.js
+++ b/routes/index.js
@@ -815,6 +815,8 @@ exports.api.datasources = (req, res) => {
 		const { uuid } = req.session || {}
 		const { tag } = req.body || {}
 
+		// FIXME if the entry already exists we will return 500 here (because of 'one')
+		// maybe use oneOrNone and put a select query in the then body
 		DB.general.one(`
 			INSERT INTO datasources (name, contributor)
 			VALUES ($1, $2)

--- a/routes/index.js
+++ b/routes/index.js
@@ -803,6 +803,7 @@ exports.api.methods = (req, res) => {
 	;`).then(results => res.status(200).json(results))
 	.catch(err => res.status(500).send(err))
 }
+// TO DO: this api is deprecated
 exports.api.datasources = (req, res) => {
 	if (req.method === 'GET') {
 		DB.general.any(`
@@ -815,8 +816,6 @@ exports.api.datasources = (req, res) => {
 		const { uuid } = req.session || {}
 		const { tag } = req.body || {}
 
-		// FIXME if the entry already exists we will return 500 here (because of 'one')
-		// maybe use oneOrNone and put a select query in the then body
 		DB.general.one(`
 			INSERT INTO datasources (name, contributor)
 			VALUES ($1, $2)

--- a/routes/save/tag/index.js
+++ b/routes/save/tag/index.js
@@ -3,10 +3,10 @@ const { DB } = include('config/')
 module.exports = (req, res) => {
 	const { name, type } = req.body || {}
 	const { uuid } = req.session || {}
-	
+
 	if (type !== 'sdgs') { // TECHNICALLY THIS SHOULD NOT HAPPEN BECAUSE sdgs CANNOT BE opencoded AS PER THE config
 		DB.general.tx(gt => {
-			return gt.one(`
+			return gt.oneOrNone(`
 				INSERT INTO tags (name, type, contributor)
 				VALUES ($1, $2, $3)
 				ON CONFLICT ON CONSTRAINT name_type_key

--- a/routes/scripts/shared/transfer_pinboards.js
+++ b/routes/scripts/shared/transfer_pinboards.js
@@ -85,13 +85,26 @@ if (action === undefined || action === 'transfer') {
             await ct.batch(cbatch);
             cbatch.clear();
             await Promise.all(Object.keys(link_map).map(async (key) => {
-                const db_id = await gt.one(`
-                    INSERT INTO extern_db (db, url_prefix)
-                    VALUES ($1, $2)
-                    ON CONFLICT ON CONSTRAINT extern_db_db_key DO NOTHING
-                    RETURNING id;
-                `, [key, link_map[key]]);
-                db_map[key] = db_id.id;
+                const read_id = await gt.any(`
+                    SELECT id FROM extern_db WHERE db = $1;
+                `, [key]);
+                if (!read_id.length) {
+                    const db_id = await gt.any(`
+                        INSERT INTO extern_db (db, url_prefix)
+                        VALUES ($1, $2)
+                        ON CONFLICT ON CONSTRAINT extern_db_db_key DO NOTHING
+                        RETURNING id;
+                    `, [key, link_map[key]]);
+                    if (db_id.length) {
+                        db_map[key] = db_id[0].id;
+                    } else {
+                        db_map[key] = await gt.one(`
+                            SELECT id FROM extern_db WHERE db = $1 LIMIT 1;
+                        `, [key]).id;
+                    }
+                } else {
+                    db_map[key] = read_id[0].id;
+                }
             }));
             const ownId = db_map[app_id];
             const pinboards = await ct.manyOrNone(`SELECT * FROM _pinboards;`);

--- a/routes/scripts/shared/transfer_pinboards.js
+++ b/routes/scripts/shared/transfer_pinboards.js
@@ -56,7 +56,7 @@ if (action === undefined || action === 'transfer') {
         `));
         gbatch.push(gt.none(`ALTER TABLE pinboards DROP CONSTRAINT IF EXISTS unique_pinboard_owner;`));
         gbatch.push(gt.none(`
-            ALTER TABLE pinboards ADD CONSTRAINT unique_pinboard_owner UNIQUE (title, owner);
+            ALTER TABLE pinboards ADD CONSTRAINT unique_pinboard_owner UNIQUE (title, owner, old_db);
         `));
         gbatch.push(gt.none(`
             CREATE TABLE IF NOT EXISTS pinboard_contributors (

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -5,17 +5,17 @@
 	const title = `${locals.metadata?.page?.title}${country_page_title ? `: ${country_page_title}` : ''}`
 	const description = locals.metadata?.site?.description[language]
 
-	const site_title = locals?.metadata?.page?.public ? 
+	const site_title = locals?.metadata?.page?.public ?
 		locals?.data?.title || locals?.display_template?.title
-		: ''
+		: null;
 
-	const site_description = locals?.metadata?.page?.public && locals?.item_description?.length 
+	const site_description = locals?.metadata?.page?.public && locals?.item_description?.length
 		? locals?.item_description[0]
-		: ''
-	const img = locals?.metadata?.page?.public && locals?.item_attachments?.length 
+		: null;
+	const img = locals?.metadata?.page?.public && locals?.item_attachments?.length
 		? locals?.item_attachments[0]
-		: ''
-	
+		: null;
+
 	const currentpage_url = locals?.metadata?.page?.currentpage_url
 
 	let ogp_locale = 'en_US'
@@ -46,8 +46,8 @@
 <meta property="og:description" content="<%= site_description ?? description %>">
 <meta property="og:image" content="<%= img ?? defaultLogoImg %>">
 <meta property="og:locale" content="<%= ogp_locale %>">
-<meta property="og:image:width" content="400" />
-<meta property="og:image:height" content="400" />
+<meta property="og:image:width" content="<%= img ? 300 : 586 %>" />
+<meta property="og:image:height" content="<%=  img ? 200 : 365 %>" />
 
 <!-- Twitter Meta Tags -->
 <meta property="twitter:url" content="<%= currentpage_url %>" >


### PR DESCRIPTION
- [x] add more instructions about the migration
- [x] fix issues with loading global settings
- [x] fix issues with insert returning
- [x] fix autopublish

this pr solves two bugs. one is that when inserting with a `on conflict do nothing` clause the query returns no rows even with the `returning` keyword so we need to run a `select` query in that case afterwards. the other bug is that pinboards got automatically published when adding a published document. this is prevented by restricting the maximum automatic status to 1.

furthermore, the migration for pinboards is updated to allow duplicate pinboards initially. those duplicates need to be manually fixed (e.g., by renaming pinboards after the migration) and then migration can be finished properly. instructions on how to do this were added to the readme