### PR TITLE
fixed forwarding issue

### DIFF
--- a/routes/forward/index.js
+++ b/routes/forward/index.js
@@ -14,7 +14,7 @@ module.exports = (req, res) => {
 	if (modules.some(d => d.type === `${object}s`)) {
 		const { read, write } = modules.find(d => d.type === `${object}s`).rights
 
-		if (object === 'pad' && (rights >= write || public)) pad(req, res) // THE || uuid IS FOR PUBLIC ACCESS DURING MOBILIZATIONS
+		if (object === 'pad' && (rights >= write.templated || public)) pad(req, res) // HERE WE ASSUME ALL FORWARDED PADS ARE TEMPLATED BECAUSE PART OF A MOBILIZATION
 		// else if (object === 'template' && rights >= modules.find(d => d.type === 'templates').rights.write) template.create(req, res)
 		// else if (object === 'mobilization' && rights >= modules.find(d => d.type === 'mobilizations').rights.write) mobilization.create(req, res)
 		// else res.redirect(`/${language}/browse/${object}s/public`)

--- a/routes/forward/pad/index.js
+++ b/routes/forward/pad/index.js
@@ -31,7 +31,8 @@ module.exports = (req, res) => {
 						UPDATE pads
 						SET date = NOW(),
 							status = 1,
-							source = $1::INT
+							source = $1::INT,
+							version = version || $2::TEXT
 						WHERE id = $2::INT
 					;`, [ id, result.id ]))
 					


### PR DESCRIPTION
The issue was introduced when "write" rights for the pads module was changed to an object with "blank" and "templated" keys. This was solved by checking for "write.templated" rights, assuming a forwarded pad would follow a template since dependent on a campaign/ mobilization (which always uses a template).

Also fixed the "version" tree for forwarded pads, which was not being updated.