### PR TITLE
fixed saving mechanism

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,6 +30,7 @@ app.use(
         'script-src-attr': ["'unsafe-inline'"],
         'style-src': csp_links,
         'connect-src': csp_links,
+        "frame-src": ["https://www.youtube.com/","https://youtube.com/","https://web.microsoftstream.com"]
       },
     },
     referrerPolicy: {

--- a/routes/import/process.js
+++ b/routes/import/process.js
@@ -10,6 +10,7 @@ module.exports = (req, res) => { // TO DO
 
 	DB.conn.tx(t => {
 		// INSERT THE TEMPLATE TO GET THE id
+		template.sections = JSON.stringify(template.sections)
 		const sql = DB.pgp.helpers.insert(template, null, 'templates')
 		return t.one(`
 			$1:raw
@@ -21,6 +22,7 @@ module.exports = (req, res) => { // TO DO
 			return t.batch(pads.map(d => {
 				d.owner = uuid
 				d.template = template_id
+				d.sections = JSON.stringify(d.sections)
 
 				return t.task(t1 => {
 					// STORE PAD INFO
@@ -69,7 +71,7 @@ module.exports = (req, res) => { // TO DO
 							}).catch(err => console.log(err)))
 						}
 
-						if (d.locations?.length) {
+						if (d.locations?.filter(d => d).length) {
 							// SAVE LOCATIONS INFO
 							d.locations.forEach(c => c.pad = pad_id)
 							const locations_sql = DB.pgp.helpers.insert(d.locations, ['pad', 'lng', 'lat'], 'locations')

--- a/routes/save/pad/index.js
+++ b/routes/save/pad/index.js
@@ -5,6 +5,8 @@ const { BlobServiceClient } = require('@azure/storage-blob')
 
 module.exports = (req, res) => {
 	const { id, tagging, locations, metadata, deletion, mobilization, source } = req.body || {}
+	if (req.body?.sections) req.body.sections = JSON.stringify(req.body.sections)
+
 	const { uuid } = req.session || {}
 
 	if (!id) { // INSERT OBJECT

--- a/routes/save/template/index.js
+++ b/routes/save/template/index.js
@@ -2,6 +2,8 @@ const { DB } = include('config/')
 
 module.exports = (req, res) => {
 	const { id, review_template, review_language, source } = req.body || {}
+	if (req.body?.sections) req.body.sections = JSON.stringify(req.body.sections)
+
 	const { uuid } = req.session || {}
 
 	if (!id) { // INSERT OBJECT

--- a/views/contribute/pad/index.ejs
+++ b/views/contribute/pad/index.ejs
@@ -1040,7 +1040,7 @@
 		content.title = title
 		if (!attr || ['title', 'lead', 'media', 'meta', 'group'].includes(attr)
 		|| sections.map(d => d.items).flat().unique('type', true).includes(attr)) {
-			content.sections = JSON.stringify(sections)
+			content.sections = sections
 		}
 		// if (!attr || attr === 'meta' || meta.unique('type', true).includes(attr)) content.meta = JSON.stringify(meta)
 		// if (!attr || attr === 'location') content.location = JSON.stringify(location)

--- a/views/contribute/pad/render.ejs
+++ b/views/contribute/pad/render.ejs
@@ -1650,37 +1650,68 @@ function addEmbed (kwargs) {
 		'contenteditable': editing
 	}).classed('padded', true)
 	.style('text-align', d => d.textalign)
-		.html(d => {
-			if (!editing && d.html.trim().isURL()) return `<a href=${d.html.trim()} target='_blank'>${d.html}</a>`
-			else return d.html
+		.each(function (d) {
+			const sel = d3.select(this)
+			if (this.innerText.trim().isURL() || d.src) {
+				renderIframe.call(this, d)
+			} else {
+				sel.style('text-align', d.textalign)
+					.html(this.innerText)
+			}
+			sel.classed('padded', !this.children.length)
 		})
-	.on('focus', function () {
-		setTimeout(_ => d3.select(this).classed('padded', true).style('text-align', 'left').html(this.innerHTML), 250)
+		// .html(d => {
+		// 	if (!editing && d.html.trim().isURL()) return `<a href=${d.html.trim()} target='_blank'>${d.html}</a>`
+		// 	else return d.html
+		// })
+	.on('focus', function (d) {
+		setTimeout(_ => {
+			d3.select(this).classed('padded', true).style('text-align', 'left')
+				.html(d.html.innerText || d.src || this.innerHTML)
+		}, 250)
 	}).on('blur', async function (d) {
 		const sel = d3.select(this)
 
-		if (this.innerText.trim().isURL()) {
-			const url = this.innerText.trim()
-			const isYoutube = url.match(/^(((http|https):\/\/)|(www\.))(?=.*youtube)/gi)
-			const isMSStream = url.match(/^(((http|https):\/\/))(?=.*microsoftstream)/gi)
+		if (this.innerText.trim().isURL() || d.src) {
+			renderIframe.call(this, d)
+		} else {
+			sel.style('text-align', d.textalign)
+				.html(this.innerText)
+		}
+		sel.classed('padded', !this.children.length)
 
-			if (isYoutube) {
-				d.src = url.replace('watch?v=', 'embed/')
-				this.innerText = null
-				sel.addElems('iframe')
-					.attrs({
-						'width': 560, 'height': 315, 'src': d.src, 'frameborder': 0,
-						'allow': 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'
-					})
-				.each(function () { this.allowfullscreen })
-			} else if (isMSStream) {
-				d.src = url.replace(/\?(.*)/gi, '?autoplay=false&amp;showinfo=true')
-				this.innerText = null
-				sel.addElems('iframe')
+		if (editing) {
+			if (!publicpage) switchButtons(lang)
+			else window.sessionStorage.setItem('changed-content', true)
+		}
+	})
+	// media.addElems('img', 'cover', d => d.src ? [d] : [])
+	//	.attr('src', d => d.src)
+
+	async function renderIframe (d) {
+		const sel = d3.select(this)
+		const url = this.innerText.trim() || d.src
+		const isYoutube = url.match(/^(((http|https):\/\/)|(www\.))(?=.*youtube)/gi)
+		const isMSStream = url.match(/^(((http|https):\/\/))(?=.*microsoftstream)/gi)
+		
+		if (isYoutube) {
+			d.src = url.replace('watch?v=', 'embed/')
+			this.innerText = null
+			sel.addElems('iframe')
+			.attrs({
+				'width': 560, 'height': 315, 'src': d.src, 'frameborder': 0,
+				'allow': 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture'
+			})
+			.each(function () { this.allowfullscreen })
+		} else if (isMSStream) {
+			d.src = url.replace(/\?(.*)/gi, '?autoplay=false&amp;showinfo=true')
+			this.innerText = null
+			sel.addElems('iframe')
 					.attrs({ 'width': 560, 'height': 315, 'src': d.src })
 					.style('border', 'none')
-				.each(function () { this.allowfullscreen })
-			} else { // TO DO: FINSIH THIS
+			.each(function () { this.allowfullscreen })
+		} else {
+			if (false) { // TO DO: FINSIH THIS
 				const screenshot = await POST('/screenshot', { src: this.innerText.trim() })
 				if (screenshot.src) {
 					d.src = screenshot.src
@@ -1704,20 +1735,12 @@ function addEmbed (kwargs) {
 						<% } %>
 					}
 				}
+			} else {
+				d.src = url
+				sel.html(`<a href='${d.src}' target='_blank'>${d.src}</a>`)
 			}
-		} else {
-			sel.style('text-align', d.textalign)
-				.html(this.innerText)
 		}
-		sel.classed('padded', !this.children.length)
-
-		if (editing) {
-			if (!publicpage) switchButtons(lang)
-			else window.sessionStorage.setItem('changed-content', true)
-		}
-	})
-	// media.addElems('img', 'cover', d => d.src ? [d] : [])
-	//	.attr('src', d => d.src)
+	}
 
 	if (focus) media.media.node().focus()
 }

--- a/views/contribute/template/index.ejs
+++ b/views/contribute/template/index.ejs
@@ -722,7 +722,7 @@
 		if (!attr || attr === 'description') content.description = description
 		if (!attr || ['lead', 'media', 'meta'].includes(attr)
 		|| sections.map(d => d.structure).flat().unique('type', true).includes(attr)) {
-			content.sections = JSON.stringify(sections)
+			content.sections = sections
 		}
 		// ALWAYS SEND fullTxt
 		content.full_text = fullTxt

--- a/views/import.ejs
+++ b/views/import.ejs
@@ -1166,7 +1166,7 @@
 		
 		template.title = title.slice(0, 99)
 		template.description = description
-		template.sections = JSON.stringify(sections)
+		template.sections = sections //JSON.stringify(sections)
 		template.full_text = full_text
 		template.medium = 'xlsx'
 		template.imported = true
@@ -1313,7 +1313,7 @@
 		} else console.log('no images to upload')
 
 		// 3) SAVE PADS
-		pads.forEach(d => d.sections = JSON.stringify(d.sections))
+		// pads.forEach(d => d.sections = JSON.stringify(d.sections))
 		// const results = await POST('/storeImport', { pads, template, mobilization })
 		addGlobalLoader()
 		const results = await POST('/upload/xlsx', { pads, template, mobilization })


### PR DESCRIPTION
Fixed the saving mechanism. The issue is the front end was sending stringified json to the backend with all the unstructured content of the pads, and this was getting intercepted by the security middleware that was trying to escape the json content as if it was a string (which indeed it was). 

I also fixed the iframe issue with embeddings by not storing the iframe (which gets removed by the same mechanism as described above) but by recreating it in the front end (views/contribute/pad/render.ejs)  every time.