### PR TITLE
added self to frame-src policy

### DIFF
--- a/app.js
+++ b/app.js
@@ -30,7 +30,7 @@ app.use(
         'script-src-attr': ["'unsafe-inline'"],
         'style-src': csp_links,
         'connect-src': csp_links,
-        "frame-src": ["https://www.youtube.com/","https://youtube.com/","https://web.microsoftstream.com"]
+        "frame-src": ["'self'","https://www.youtube.com/","https://youtube.com/","https://web.microsoftstream.com"]
       },
     },
     referrerPolicy: {


### PR DESCRIPTION
Added 'self' to frame-src policy to enable showing pads side-by-side (e.g. in the case of action plans/closing forms)