### PR TITLE
Add foot note to trust this device checkbox

### DIFF
--- a/routes/login/confirm-device.js
+++ b/routes/login/confirm-device.js
@@ -102,6 +102,7 @@ exports.resendCode = async (req, res, next) => {
     email,
     uuid,
     conn: DB.general,
+    req,
   })
     .then(() => {
       req.session.errormessage = "OTP code sent successfully!";

--- a/routes/login/device-info.js
+++ b/routes/login/device-info.js
@@ -13,12 +13,15 @@ exports.deviceInfo = (req) => {
 exports.sendDeviceCode = (_kwarg) => {
   const { email : sendEmail } = include('routes/helpers/')
 
-  const { conn, uuid, email, name } = _kwarg;
+  const { conn, uuid, email, name, req } = _kwarg;
   let code = 0;
   while (`${code}`.length < 6) {
     code += Math.floor(Math.random() * 1000000);
     code %= 1000000;
   }
+
+  const { protocol, host } = req || {}
+  const resetLink = `${protocol}://${host}/forget-password`;
 
   // Save the code to the database
   return conn
@@ -42,7 +45,7 @@ exports.sendDeviceCode = (_kwarg) => {
           <p>Please confirm this device using the OTP (One Time Password) below:</p>
           <h3>${code}</h3>
           <p>This OTP will expire in 10 minutes.</p>
-          <p>If you are receiving this email and did not initiate this request, your account might be compromised. Please reset your password or contact system administrators.</p>
+          <p>If you are receiving this email and did not initiate this request, your account might be compromised. Please <a href="${resetLink}">reset your password</a> or contact system administrators.</p>
           <br/>
           <p>Best regards,</p>
           <p>AccLab Global Team</p>

--- a/routes/login/process.js
+++ b/routes/login/process.js
@@ -191,7 +191,7 @@ module.exports = (req, res, next) => {
 
 								// Device is not part of the trusted devices
 								sendDeviceCode({
-									name: result.name, email: result.email, uuid: result.uuid, conn: t
+									name: result.name, email: result.email, uuid: result.uuid, conn: t, req
 								})
 								.then(()=>{
 									req.session.confirm_dev_origins = {	

--- a/routes/save/contributor/index.js
+++ b/routes/save/contributor/index.js
@@ -193,7 +193,7 @@ module.exports =async (req, res) => {
 					sessionupdate({
 						conn: t,
 						whereClause: `sess ->> 'uuid' = $1`,
-						queryValues: [uuid]
+						queryValues: [id]
 					})
 
 				} else {
@@ -232,10 +232,11 @@ module.exports =async (req, res) => {
 						WHERE uuid = $2
 					;`, [ app_languages, id ])
 					.then(result => {
-						const { device } = req.session
-						const sess = { ...result, is_trusted, device: {...device, is_trusted}}
-						Object.assign(req.session, datastructures.sessiondata(sess))
-						return null
+						sessionupdate({
+							conn: t,
+							whereClause: `sess ->> 'uuid' = $1`,
+							queryValues: [id]
+						})
 					}).catch(err => console.log(err))
 				}
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -51,6 +51,8 @@
 					<div class='alert session-alert pt-5'>
 						<input type='checkbox' id='is_trusted' name='is_trusted' >
 						<small  for='is_trusted'>Trust this device.</small>
+						<br/>
+						<small>If this is the first time you are adding this device, a one-time password will be sent to your email for confirmation.</small> 
 					</div>
 				</li>
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -52,7 +52,7 @@
 						<input type='checkbox' id='is_trusted' name='is_trusted' >
 						<small  for='is_trusted'>Trust this device.</small>
 						<br/>
-						<small>If this is the first time you are trusting this device, a one-time password will be sent to your email for confirmation.</small> 
+						<small>You will get an email to confirm your device as trusted, unless you have done so previously.</small> 
 					</div>
 				</li>
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -52,7 +52,7 @@
 						<input type='checkbox' id='is_trusted' name='is_trusted' >
 						<small  for='is_trusted'>Trust this device.</small>
 						<br/>
-						<small>If this is the first time you are adding this device, a one-time password will be sent to your email for confirmation.</small> 
+						<small>If this is the first time you are trusting this device, a one-time password will be sent to your email for confirmation.</small> 
 					</div>
 				</li>
 

--- a/views/login.ejs
+++ b/views/login.ejs
@@ -52,7 +52,7 @@
 						<input type='checkbox' id='is_trusted' name='is_trusted' >
 						<small  for='is_trusted'>Trust this device.</small>
 						<br/>
-						<small>You will get an email to confirm your device as trusted, unless you have done so previously.</small> 
+						<small>You will get an email to confirm your device as trusted, unless you have done so previously.</small> <!-- TO DO: TRANSLATE -->
 					</div>
 				</li>
 


### PR DESCRIPTION
Since the device trust/confirmation is a new feature for the platform user, adding a footnote that the user should expect an OTP email will help prevent them from thinking there is an attempted attack on their account when they see the device confirmation email. 
I also added a reset password link in the OTP confirmation email so user can directly click from the email to reset their password if needed.