### PR TITLE
gtranslate fix

### DIFF
--- a/public/js/browse/load.js
+++ b/public/js/browse/load.js
@@ -1,4 +1,3 @@
-import { initGTranslate } from '/js/config/gtranslate.js'
 import { setDownloadOptions } from '/js/browse/download.js';
 import { initSlideshowNavigation } from '/js/browse/keyboard.interactions.js';
 import {
@@ -18,8 +17,6 @@ import { checkForEnter, fixLabel, getMediaSize } from '/js/main.js';
 
 async function DOMLoad() {
   if (!mediaSize) var mediaSize = getMediaSize();
-
-  await initGTranslate();
 
   const object = d3.select('data[name="object"]').node().value;
   const space = d3.select('data[name="space"]').node().value;

--- a/public/js/config/gtranslate.js
+++ b/public/js/config/gtranslate.js
@@ -10,17 +10,10 @@ export async function initGTranslate() {
   function setCookie(key, value, expiry) {
     const expires = new Date();
     expires.setTime(expires.getTime() + expiry * 24 * 60 * 60 * 1000);
-    document.cookie = `${key}=${value};expires=${expires.toUTCString()};domain=${mainHost}`;
+    document.cookie = `${key}=${value};domain=${mainHost}`;
   }
 
   d3.select('#gtranslate-dummy-lang').style('display', 'none');
-  new google.translate.TranslateElement(
-    {
-      pageLanguage: 'en',
-      layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
-    },
-    'google_translate_element',
-  );
 
   function rewriteUrl(lang, reload = false) {
     if (!lang) {
@@ -32,7 +25,7 @@ export async function initGTranslate() {
     currentUrl.pathname = newPath;
     const newUrl = `${currentUrl}`;
 
-    if(newUrl !== window.location.href ){
+    if (newUrl !== window.location.href) {
       if (reload) window.location.href = newUrl;
       else window.history.replaceState({}, '', newUrl);
     }
@@ -60,26 +53,50 @@ export async function initGTranslate() {
         try {
           callback({ oldValue: lastCookie, newValue: cookie });
         } finally {
+          if (!lastCookie) {
+            new google.translate.TranslateElement(
+              {
+                pageLanguage: 'en',
+                layout: google.translate.TranslateElement.InlineLayout.SIMPLE,
+              },
+              'google_translate_element',
+            );
+          }
           lastCookie = cookie;
         }
       }
     }, interval);
   }
 
+  let langset = false;
   listenCookieChange(({ oldValue, newValue }) => {
-    let seengtranslate = false
+    let seengtranslate = false;
+    let lang = language;
+
+    const url = new URL(window.location);
+    let urlLang = null;
+    const pathname = url.pathname.substring(1);
+    if (pathname.split('/').length > 1) {
+      urlLang = `${pathname.split('/')[0]}`;
+    }
+
+    if (!oldValue && urlLang && !langset) {
+      setCookie('googtrans', `/en/${urlLang}`, 1);
+      langset = true;
+      return;
+    }
+
     newValue.split('; ').forEach((cookie) => {
       const [name, value] = cookie.split('=');
       if (name === 'googtrans') {
-        seengtranslet = true;
-        const lang = value.split('/')[2];
+        seengtranslate = true;
+        lang = value.split('/')[2];
         updateDomTree(lang);
         rewriteUrl(lang);
-      } 
+      }
     });
-    if(!seengtranslate) rewriteUrl('en', true);
+
+    if (!seengtranslate) rewriteUrl('en', true);
+    // && !['pt','es','fr'].includes(urlLang)
   }, 1000);
-
-  setCookie('googtrans', `/en/${language}`, 1);
-
 }

--- a/public/js/config/gtranslate.js
+++ b/public/js/config/gtranslate.js
@@ -10,6 +10,7 @@ export async function initGTranslate() {
   function setCookie(key, value, expiry) {
     const expires = new Date();
     expires.setTime(expires.getTime() + expiry * 24 * 60 * 60 * 1000);
+    // document.cookie = `${key}=${value};expires=${expires.toUTCString()};domain=${mainHost}`;
     document.cookie = `${key}=${value};domain=${mainHost}`;
   }
 

--- a/public/js/config/gtranslate.js
+++ b/public/js/config/gtranslate.js
@@ -32,8 +32,10 @@ export async function initGTranslate() {
     currentUrl.pathname = newPath;
     const newUrl = `${currentUrl}`;
 
-    if (reload) window.location.href = newUrl;
-    else window.history.replaceState({}, '', newUrl);
+    if(newUrl !== window.location.href ){
+      if (reload) window.location.href = newUrl;
+      else window.history.replaceState({}, '', newUrl);
+    }
   }
 
   // IF THE SELECTED LANGUAGE IS ONE OF THE MODULE LANGUAGES, IGNORE GOOGLE TRANSLATE FOR VOCABULARY OBJ
@@ -51,7 +53,7 @@ export async function initGTranslate() {
 
   // LISTEN TO CHANGES IN G_LANGUAGE COOKIES
   function listenCookieChange(callback, interval = 1000) {
-    let lastCookie = document.cookie;
+    let lastCookie = null;
     setInterval(() => {
       let cookie = document.cookie;
       if (cookie !== lastCookie) {
@@ -65,14 +67,17 @@ export async function initGTranslate() {
   }
 
   listenCookieChange(({ oldValue, newValue }) => {
+    let seengtranslate = false
     newValue.split('; ').forEach((cookie) => {
       const [name, value] = cookie.split('=');
       if (name === 'googtrans') {
+        seengtranslet = true;
         const lang = value.split('/')[2];
         updateDomTree(lang);
         rewriteUrl(lang);
-      } else rewriteUrl('en', true);
+      } 
     });
+    if(!seengtranslate) rewriteUrl('en', true);
   }, 1000);
 
   setCookie('googtrans', `/en/${language}`, 1);

--- a/public/js/contribute/pad/load.js
+++ b/public/js/contribute/pad/load.js
@@ -1,4 +1,3 @@
-import { initGTranslate } from '/js/config/gtranslate.js'
 import { selectReviewLanguage } from '/js/contribute/pad/main.js';
 import { renderPad } from '/js/contribute/pad/render.js';
 import { partialSave, saveAndSubmit } from '/js/contribute/pad/save.js';
@@ -7,8 +6,6 @@ import { getMediaSize } from '/js/main.js';
 
 async function DOMLoad() {
   if (!mediaSize) var mediaSize = getMediaSize();
-  
-  await initGTranslate();
 
   const { id, type, source } = JSON.parse(
     d3.select('data[name="pad"]').node()?.value,

--- a/public/js/load.js
+++ b/public/js/load.js
@@ -1,5 +1,5 @@
 import { languages } from '/js/config/main.js'
-import { POST } from '/js/fetch.js';
+import { initGTranslate } from '/js/config/gtranslate.js'
 import {
   ensureIcon,
   expandstats,
@@ -13,6 +13,8 @@ import {
 if (!mediaSize) var mediaSize = getMediaSize();
 
 async function DOMLoad() {
+  await initGTranslate()
+
   d3.selectAll('[data-vocab]').html(function () {
     const vocab =
       this.dataset.vocab ||

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -97,10 +97,10 @@
 <!-- <script type='text/javascript' src='/js/upload.js'></script> -->
 
 <!-- Google Translate CDN -->
-<script type='text/javascript' src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit" nonce="<%- nonce %>"></script>
+<script type='text/javascript' src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit" nonce="<%- nonce %>"></script>
 <!-- <script src = '/socket.io/socket.io.js'></script> -->
 
 <link rel='stylesheet' href='https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined'>
-<link href="//maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
+<link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">
 
 <link rel='stylesheet' type='text/css' href='/css/dispatch.css'>


### PR DESCRIPTION
Fixing the malfunctioning gtranslate function and ensure compatibility of the cookiestore with Firefox and Safari.

TODO: For testing purposes, verify whether Google Translate is being set twice in both the staging and other environments. In the local environment, the gtranslate cookie is being set twice, which prevents the page from reloading when the Google widget is closed.