### PR TITLE
fixed issue with follow ups and requesting resource

### DIFF
--- a/public/js/browse/render.js
+++ b/public/js/browse/render.js
@@ -1947,11 +1947,13 @@ export function renderVignette(_section, _kwargs) {
     // render.tags(entry.body)
     render.title(entry.body);
     render.owner(entry.body);
+    if (page.type === 'private') {
+      render.followup(entry.body);
+    }
     // if (data.img?.length === 0) render.txt(entry.body)
     render.txt(entry.body);
     if (page.type === 'private') {
       render.metainfo(entry.body);
-      render.followup(entry.body);
     }
     render.tags(entry.body);
     // if (mediaSize === 'xs') render.stats(entry.foot)

--- a/public/js/config/main.js
+++ b/public/js/config/main.js
@@ -19,7 +19,7 @@ async function getCurrentLanguage () {
 }
 async function getRegisteredLanguages () {
   let { languages } = JSON.parse(
-    d3.select('data[name="site"]').node()?.value,
+    d3.select('data[name="site"]').node()?.value || '{}',
   );
   if (!languages?.length) {
     languages = (await POST('/load/metadata', { feature: 'languages' })).languages;

--- a/public/js/contribute/pad/render.js
+++ b/public/js/contribute/pad/render.js
@@ -3615,7 +3615,7 @@ export async function addAttachment(kwargs) {
 
   const { data, lang, section, sibling, container, focus, objectdata } =
     kwargs || {};
-  const { object } = objectdata || {};
+  const { object, type: objecttype } = objectdata || {};
   let { id, level, type, name, srcs, instruction, constraint, required } =
     data || {};
   if (!level) level = 'meta';
@@ -3704,15 +3704,6 @@ export async function addAttachment(kwargs) {
                   `/request/resource?${params.toString()}`,
                 ),
               );
-              // resolve(
-              //   window.location.replace(
-              //     `/request/resource?uri=${encodeURI(
-              //       d.uri,
-              //     )}&pad_id=${pad_id}&element_id=${
-              //       meta.id
-              //     }&name=${name}&type=${type}`,
-              //   ),
-              // );
             });
           },
         });
@@ -3748,7 +3739,7 @@ export async function addAttachment(kwargs) {
     });
     const result = await renderPromiseModal(item);
     if (result === null) {
-      if (!srcs.length) await meta.rmMedia();
+      if (!srcs.length && objecttype !== 'templated') await meta.rmMedia();
     } else {
       d3.selectAll('div.screen').classed('hide', true);
       const screen = d3

--- a/public/scss/_browse.lg.scss
+++ b/public/scss/_browse.lg.scss
@@ -1622,10 +1622,10 @@ div.browse {
                   padding: 0 5px;
                   border: 1px solid $c-light-blue;
                   outline: none;
-                  background-color: transparent;
-                  font-size: $t-small;
+                  background-color: $c-light-blue;
+                  font-size: $t-mid-small;
                   line-height: 1.5em;
-                  color: $c-light-blue;
+                  color: #FFF;
                   cursor: pointer;
                 }
                 .dropdown {

--- a/public/scss/_browse.m.scss
+++ b/public/scss/_browse.m.scss
@@ -1580,10 +1580,10 @@ div.browse {
                   padding: 0 5px;
                   border: 1px solid $c-light-blue;
                   outline: none;
-                  background-color: transparent;
-                  font-size: $t-small;
+                  background-color: $c-light-blue;
+                  font-size: $t-mid-small;
                   line-height: 1.5em;
-                  color: $c-light-blue;
+                  color: #FFF;
                   cursor: pointer;
                 }
                 .dropdown {

--- a/public/scss/_browse.sm.scss
+++ b/public/scss/_browse.sm.scss
@@ -1565,10 +1565,10 @@ div.browse {
                     padding: 0 5px;
                     border: 1px solid $c-light-blue;
                     outline: none;
-                    background-color: transparent;
-                    font-size: $t-small;
+                    background-color: $c-light-blue;
+                    font-size: $t-mid-small;
                     line-height: 1.5em;
-                    color: $c-light-blue;
+                    color: #FFF;
                     cursor: pointer;
                   }
                   .dropdown {

--- a/public/scss/_browse.xl.scss
+++ b/public/scss/_browse.xl.scss
@@ -1602,10 +1602,10 @@ div.browse {
                   padding: 0 5px;
                   border: 1px solid $c-light-blue;
                   outline: none;
-                  background-color: transparent;
-                  font-size: $t-small;
+                  background-color: $c-light-blue;
+                  font-size: $t-mid-small;
                   line-height: 1.5em;
-                  color: $c-light-blue;
+                  color: #FFF;
                   cursor: pointer;
                 }
                 .dropdown {

--- a/routes/browse/pads/load/data.js
+++ b/routes/browse/pads/load/data.js
@@ -326,10 +326,13 @@ module.exports = async kwargs => {
 							AND pad IN $3:raw
 						;`, [ safeArr(results.map(d => d.collection), -1), ownId, padlist ])
 						.then(async pinnedpads => {
-							pinnedpads.forEach(d => {
-								d.followups = results.find(c => c.collection === d.collection)?.followups
-								d.followups.source = d.id
-								delete d.collection
+							pinnedpads = pinnedpads.map(d => {
+								const { collection, ...datum } = d
+								datum.followups = Object.assign({}, results.find(c => c.collection === d.collection)?.followups)
+								if (datum.followups) {
+									datum.followups.source = d.id
+								}
+								return datum
 							})
 							// GET THE count OF FOLLOWUPS
 							for (let p = 0; p < pinnedpads.length; p ++) {


### PR DESCRIPTION
Fixed an issue reported several time relating to a depth campaign. 
First, contributors were having trouble finding the "follow up" button, so I made it more salient. 
Second, there was an issue in the backend in how follow up contributions were counted (a problem related to assign a var to a shallow copy of an object). 
Third, there was an issue of the consent module disappearing from templates. This was because there was no check for whether the pad was templated. On non templated pads, the attachment request is deleted if nothing is attached. This is not a behavior we want for templated pads. 
