### PR TITLE
fixed issue of templated pad not displaying

### DIFF
--- a/config/edit/sm.js
+++ b/config/edit/sm.js
@@ -13,7 +13,7 @@ exports.own_app_url = 'https://solutions.sdg-innovation-commons.org/';
 
 // DESIRED MODULES
 exports.modules = [
-  { type: 'pads', rights: { read: 0, write: { blank: 2, templated: 1 } } },
+  { type: 'pads', rights: { read: 0, write: { blank: 2, templated: 0 } } }, // templated: 0 IS FOR PUBLIC MOBILIZATIONS
   { type: 'pinboards', rights: { read: 0, write: 1 } },
   { type: 'templates', rights: { read: 2, write: 2 } },
   // { type: 'files', rights: { read: 0, write: 1 } },

--- a/public/js/contribute/pad/render.js
+++ b/public/js/contribute/pad/render.js
@@ -4215,7 +4215,7 @@ export async function renderPad(kwargs) {
 
   if (editing && !id && type === 'templated') {
     // GET TEMPLATE DATA
-    const { sections } = await POST('/load/template', { id: pad.template.id });
+    const { sections } = await POST('/load/template', { id: pad.template.id, mainobject });
 
     // APPEND locked_excerpt TO THE pad data DOM ELEMENT
     const locked_excerpt =
@@ -4307,6 +4307,7 @@ export async function renderPad(kwargs) {
         // GET TEMPLATE DATA
         const { sections } = await POST('/load/template', {
           id: pad.template.id,
+          mainobject,
         });
 
         // APPEND locked_excerpt TO THE pad data DOM ELEMENT

--- a/routes/contribute/template/authorization.js
+++ b/routes/contribute/template/authorization.js
@@ -3,8 +3,13 @@ const { safeArr, DEFAULT_UUID } = include('routes/helpers/')
 
 module.exports = _kwargs => {
 	const conn = _kwargs.connection || DB.conn
-	const { uuid, rights, id, collaborators } = _kwargs
-	const { read, write } = modules.find(d => d.type === 'templates')?.rights
+	const { uuid, rights, id, collaborators, mainobject } = _kwargs
+	let { read, write } = modules.find(d => d.type === 'templates')?.rights
+	if (['pad', 'review'].includes(mainobject)) {
+		// IF THE REQUEST IS COMING FROM A PAD OR A REVIEW PAGE
+		const { write: padwrite } = modules.find(d => d.type === 'pads')?.rights
+		if (typeof padwrite === 'object') read = padwrite.templated
+	}
 	const collaborators_ids = safeArr(collaborators.map(d => d.uuid), uuid ?? DEFAULT_UUID) //.filter(d => d.rights >= (write ?? Infinity)).map(d => d.uuid)
 
 	if (rights < write) {

--- a/routes/contribute/template/load/data.js
+++ b/routes/contribute/template/load/data.js
@@ -7,7 +7,7 @@ module.exports = async kwargs => {
 	const conn = kwargs.connection ? kwargs.connection : DB.conn
 	let { req, authorized } = kwargs || {}
 
-	let { id, source } = Object.keys(req.query)?.length ? req.query : Object.keys(req.body)?.length ? req.body : {}
+	let { id, source, mainobject } = Object.keys(req.query)?.length ? req.query : Object.keys(req.body)?.length ? req.body : {}
 	let workingID = id ?? source
 	if (!workingID) return { message: 'No id found.' }
 
@@ -15,7 +15,7 @@ module.exports = async kwargs => {
 	const language = checklanguage(req.params?.language || req.query.language || req.body.language || req.session.language)
 
 	if (authorized === undefined) {
-		const authorization = await check_authorization({ connection: conn, uuid, id, rights, collaborators })
+		const authorization = await check_authorization({ connection: conn, uuid, id, rights, collaborators, mainobject })
 		authorized = authorization.authorized
 	}
 


### PR DESCRIPTION
Fixed the issue of templates not displaying on templated pads. This was because of rights setting in the config file and the new ajax calls approach. Now, if the call for template data comes from a pad or a review, the system looks for the writes to write a templated pad, and not to read a template (as the prior is generally <= to the latter). This is more coherent.