### PR TITLE
added transpose location option for csv download

### DIFF
--- a/public/js/browse/download.js
+++ b/public/js/browse/download.js
@@ -152,6 +152,15 @@ export async function setDownloadOptions() {
         default: true,
         classname: 'hide csv xlsx json geojson',
       });
+      opts.push({
+        node: 'input',
+        type: 'checkbox',
+        name: 'transpose_locations',
+        value: true,
+        placeholder: vocabulary['transpose locations'],
+        default: true,
+        classname: 'hide csv',
+      });
     }
     if (
       metafields.some((d) => !['tag', 'index', 'location'].includes(d.type))

--- a/public/js/config/translations.js
+++ b/public/js/config/translations.js
@@ -585,6 +585,63 @@ export const fullVocabulary = {
       singular: 'Fonte de dados',
     },
   },
+  gender: {
+    // USED
+    en: {
+      plural: 'Genders',
+      singular: 'Gender',
+    },
+    fr: {
+      plural: 'Genres',
+      singular: 'Genre',
+    },
+    es: {
+      plural: 'Géneros',
+      singular: 'Género',
+    },
+    pt: {
+      plural: 'Gêneros',
+      singular: 'Gênero',
+    },
+  },
+  position: {
+    // USED
+    en: {
+      plural: 'Positions',
+      singular: 'Position',
+    },
+    fr: {
+      plural: 'Positions',
+      singular: 'Position',
+    },
+    es: {
+      plural: 'Posiciones',
+      singular: 'Posición',
+    },
+    pt: {
+      plural: 'Posições',
+      singular: 'Posição',
+    },
+  },
+  rights: {
+    // USED
+    en: {
+      plural: 'Rights',
+      singular: 'Right',
+    },
+    fr: {
+      plural: 'Droits',
+      singular: 'Droit',
+    },
+    es: {
+      plural: 'Derechos',
+      singular: 'Derecho',
+    },
+    pt: {
+      plural: 'Direitos',
+      singular: 'Direito',
+    },
+  },
   'experiment status': {
     // USED
     en: 'Experiment status',
@@ -2289,6 +2346,13 @@ Se você tiver alguma dúvida ou preocupação, sinta-se à vontade para entrar 
     fr: 'Inclure les emplacements',
     es: 'Incluir las ubicaciones',
     pt: 'Incluir os locais',
+  },
+  'transpose locations': {
+    // USED
+    en: 'Transpose locations',
+    fr: 'Transposer les emplacements',
+    es: 'Transponer las ubicaciones',
+    pt: 'Transpor os locais',
   },
   'include metafields': {
     // USED


### PR DESCRIPTION
Added a transpose locations option for csv downloads so that rows are repeated to have only one location.
This is the use case for the ITM unit in Panama.
I also added a few missing vocabulary items.