### PR TITLE
Use restricted routes in login platform config

### DIFF
--- a/config/edit/login.js
+++ b/config/edit/login.js
@@ -63,27 +63,14 @@ exports.view_display = 'page';
 // OPTIONS: 'mosaic', 'carousel'
 exports.welcome_module = 'carousel';
 
-exports.allowed_routes = [
-  '/version',
-  '/sitemap.xml',
-  '/robots.txt',
-  '/login',
-  '/sso-inits',
-  '/auth/openid/return',
-  '/transfer',
-  '/logout/:session',
-  '/reset/:token',
-  '/forget-password',
-  '/reset-password',
-  '/confirm-email/:token',
-  '/confirm-device',
-  '/resend-otp-code',
-  '/remove-trusted-device',
+exports.allowed_routes = [];
 
-  '/load/*',
-  '/:lang/contribute/*',
-  '/:lang/edit/contributor',
-  '/:lang/browse/contributors/*',
+exports.restricted_routes = [
+  '/:lang/home',
+  '/:lang/browse/pads/*',
+  '/:lang/browse/templates/*',
+  '/:lang/browse/reviews/*',
+  '/:lang/browse/mobilizations/*',
+  '/:lang/preview/*',
+  '/upload/*',
 ];
-
-exports.restricted_routes = [];


### PR DESCRIPTION
This is a quick fix for issues #249 and #248. These pages are calling API endpoints in the background which has not been set in the config file for login platform. Now, the config file explicitly allows all routes except those configured in the restricted routes variable.