### PR TITLE
fixed getInnerText for empty fields

### DIFF
--- a/public/js/contribute/pad/save.js
+++ b/public/js/contribute/pad/save.js
@@ -338,8 +338,8 @@ async function compileContent(attr) {
     let itemstext = '';
     const sel = d3.select(this);
 
-    const section_title = (sel.select('.section-header h1').node() || {})
-      .innerText;
+    // const section_title = (sel.select('.section-header h1').node() || {}).innerText;
+    const section_title = getInnerText(sel.select('.section-header h1'));
     const section_lead = getInnerText(sel.select('.media-lead'));
     const section_instruction = (
       sel.select('.media-repeat button div').node() || {}

--- a/public/js/main.js
+++ b/public/js/main.js
@@ -16,7 +16,8 @@ export function getInnerText(sel) {
   if (node.innerText) {
     return node.innerText;
   }
-  return `${node}`;
+  // return `${node}`;
+  return null
 }
 
 const debugging = false;


### PR DESCRIPTION
A minor tweak to the the getInnerText function to prevent saving empty content as a stringified DOM object