### PR TITLE
show tabs if there are published pads

### DIFF
--- a/views/browse/index.ejs
+++ b/views/browse/index.ejs
@@ -105,10 +105,9 @@
 
 
 			<% 
-				const anytabs = ['private', 'curated', 'shared', 'reviewing'].some(c => locals.stats?.[c] > 0) 
+				const anytabs = ['private', 'curated', 'shared', 'reviewing', 'all'].some(c => locals.stats?.[c] > 0) 
 					|| (locals.pinboards_list ?? []).filter(d => d.count)?.length > 0
 			%>
-
 			<% 
 				if (!publicpage
 					&& rights >= (modules.find(d => d.type === object)?.rights.read ?? Infinity)


### PR DESCRIPTION
This PR addresses the issue reported by Anna. As the Head of Solution Mapping, Anna observed that tabs were not displaying when she accessed the experiment platform. This issue arose because the condition to render tabs did not account for all published pads. Since Anna has never contributed to the experiment platform, she could only see published pads. This PR resolves the issue by ensuring that tabs are rendered if there are any published pads.