### PR TITLE
fixed multi entry checklists in xlsx import

### DIFF
--- a/public/js/contribute/xlsx/main.js
+++ b/public/js/contribute/xlsx/main.js
@@ -1232,7 +1232,7 @@ export async function compilePads(idx, structureOnly = false) {
                           c.entries[i].some((b) =>
                             typeof b === 'string' && typeof d === 'string'
                               ? b.toLowerCase().trim() ===
-                                b.toLowerCase().trim()
+                                d.toLowerCase().trim()
                               : b === d,
                           )
                         )


### PR DESCRIPTION
there was an issue in the xlsx import module when trying to add lists of strings to a checklist type (all entries were selected). the issue is fixed