### PR TITLE
add website analytics and user registration metrics to platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,3 +219,7 @@ make script ENV=.exp.env CMD=transfer_pinboards.js ACTION=finish
 make script ENV=.sm.env CMD=transfer_pinboards.js ACTION=finish
 make script ENV=.global.env CMD=transfer_pinboards.js ACTION=finish
 ```
+
+## Monitoring usage
+
+As of 2024-07-31, we have added a simple pageviews counter. We chose [Goat Counter](https://www.goatcounter.com) because it's completely open source, independent, and free for small sites. Usage statistics are visible here: https://sdg-innovation-commons.goatcounter.com/. 

--- a/app.js
+++ b/app.js
@@ -47,6 +47,7 @@ app.use(
           (req, res) => `'nonce-${res.locals.nonce}'`,
           'sha256-NNiElek2Ktxo4OLn2zGTHHeUR6b91/P618EXWJXzl3s=',
           'strict-dynamic',
+          "https://gc.zgo.at",
         ]),
         'script-src-attr': [
           "'self'",
@@ -54,7 +55,9 @@ app.use(
           'sdg-innovation-commons.org',
         ],
         'style-src': csp_links,
-        'connect-src': csp_links,
+        'connect-src': csp_links.concat([
+          "https://sdg-innovation-commons.goatcounter.com/count",
+        ]),
         'frame-src': [
           "'self'",
           '*.sdg-innovation-commons.org',

--- a/init.sql
+++ b/init.sql
@@ -372,3 +372,20 @@ ADD CONSTRAINT unique_email UNIQUE (email);
 
 ALTER TABLE trusted_devices
 ADD CONSTRAINT unique_user_device UNIQUE (user_uuid, device_os, device_browser, session_sid, duuid1, duuid2, duuid3);
+
+
+-- Add created_at column and set its value for existing users
+ALTER TABLE public.users
+ADD COLUMN created_at timestamp with time zone;
+
+-- Update created_at column with invited_at value for existing users
+UPDATE public.users
+SET created_at = invited_at;
+
+-- Set default value for created_at column for new users
+ALTER TABLE public.users
+ALTER COLUMN created_at SET DEFAULT now();
+
+-- Add last_login column
+ALTER TABLE public.users
+ADD COLUMN last_login timestamp with time zone;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node app.js",
     "sass": "sass --watch public/scss:public/css",
     "sass-deploy": "sass public/scss:public/css",
-    "dev": "nodemon app.js",
+    "dev": "source .env && nodemon app.js",
     "lint": "./node_modules/.bin/eslint .",
     "lint-fix": "./node_modules/.bin/eslint . --fix",
     "pretty": "prettier . --write"

--- a/public/js/browse/chart.js
+++ b/public/js/browse/chart.js
@@ -1,6 +1,7 @@
 import { getCurrentLanguage } from '/js/config/main.js';
 
 let chart,
+  allData,    
   rendered = false;
 
 function onLoad() {

--- a/public/js/browse/chart.js
+++ b/public/js/browse/chart.js
@@ -21,7 +21,7 @@ function setupPage() {
   // Create canvas for chart
   metricsContainer
     .append('canvas')
-    .attr('id', 'userChart')
+    .attr('id', 'user-chart')
     .attr('width', 800)
     .attr('height', 400);
 }
@@ -84,7 +84,7 @@ function displayTotalCounts(ssoData, nonSsoData) {
 }
 
 async function renderChart(labels, ssoData, nonSsoData, year) {
-  const ctx = document.getElementById('userChart').getContext('2d');
+  const ctx = document.getElementById('user-chart').getContext('2d');
   const language = await getCurrentLanguage();
 
   if (chart) {

--- a/public/js/browse/chart.js
+++ b/public/js/browse/chart.js
@@ -1,0 +1,170 @@
+import { getCurrentLanguage } from '/js/config/main.js';
+
+let chart,
+  rendered = false;
+
+function onLoad() {
+  setupPage();
+  fetchData();
+}
+
+function setupPage() {
+  const metricsContainer = d3.select('#metrics');
+
+  // Create filter container
+  metricsContainer
+    .append('div')
+    .attr('id', 'year-filter')
+    .classed('filter', true);
+
+  // Create canvas for chart
+  metricsContainer
+    .append('canvas')
+    .attr('id', 'userChart')
+    .attr('width', 800)
+    .attr('height', 400);
+}
+
+function fetchData(year) {
+  const url = `/apis/fetch/user-metrics?year=${year || null}`;
+
+  fetch(url)
+    .then((response) => response.json())
+    .then((results) => {
+      const { data, years } = results;
+
+      // Convert period strings to labels
+      const labels = data.map((d) => d.period.trim());
+      const ssoData = data.map((d) => +d.sso_count);
+      const nonSsoData = data.map((d) => +d.non_sso_count);
+
+      renderChart(labels, ssoData, nonSsoData, year);
+
+      allData = results;
+
+      if (!rendered) {
+        populateYears(years);
+        rendered = true;
+      }
+
+      displayTotalCounts(ssoData, nonSsoData);
+    });
+}
+
+function populateYears(years) {
+  const filterContainer = d3.select('#year-filter');
+
+  filterContainer.append('label').attr('for', 'year').text('Year: ');
+
+  // Create select dropdown
+  const yearSelect = filterContainer.append('select').attr('id', 'year');
+
+  yearSelect.append('option').attr('value', '').text('All Years');
+  yearSelect
+    .selectAll('option.year')
+    .data(years)
+    .enter()
+    .append('option')
+    .attr('class', 'year')
+    .attr('value', (d) => d.year)
+    .text((d) => d.year);
+
+  yearSelect.on('change', function () {
+    const year = d3.select(this).property('value');
+    fetchData(year);
+  });
+}
+
+function displayTotalCounts(ssoData, nonSsoData) {
+  const totalSso = d3.sum(ssoData);
+  const totalNonSso = d3.sum(nonSsoData);
+  const totalCounts = totalSso + totalNonSso;
+  d3.select('#metrics-count').text(`${totalCounts}`)
+}
+
+async function renderChart(labels, ssoData, nonSsoData, year) {
+  const ctx = document.getElementById('userChart').getContext('2d');
+  const language = await getCurrentLanguage();
+
+  if (chart) {
+    chart.destroy();
+  }
+
+  chart = new Chart(ctx, {
+    type: 'line',
+    data: {
+      labels: labels,
+      datasets: [
+        {
+          label: 'SSO Registrations',
+          data: ssoData,
+          borderColor: 'rgba(75, 192, 192, 1)',
+          backgroundColor: 'rgba(75, 192, 192, 0.2)',
+          fill: false,
+          tension: 0.4,
+        },
+        {
+          label: 'Non-SSO Registrations',
+          data: nonSsoData,
+          borderColor: 'rgba(255, 99, 132, 1)',
+          backgroundColor: 'rgba(255, 99, 132, 0.2)',
+          fill: false,
+          tension: 0.4,
+        },
+      ],
+    },
+    options: {
+      plugins: {
+        filler: {
+          propagate: false,
+        },
+        title: {
+          display: true,
+          text: year
+            ? `User Registrations for ${year}`
+            : 'User Registrations by Year',
+        },
+      },
+      interaction: {
+        intersect: false,
+      },
+      scales: {
+        x: {
+          title: {
+            display: true,
+            text: year ? 'Months' : 'Years',
+          },
+        },
+        y: {
+          beginAtZero: true,
+          title: {
+            display: true,
+            text: 'Registrations',
+          },
+        },
+      },
+      onClick: (e) => {
+        const points = chart.getElementsAtEventForMode(e, 'nearest', { intersect: true }, true);
+
+        if (points.length) {
+          const point = points[0];
+          const datasetIndex = point.datasetIndex;
+          const index = point.index;
+          const value = chart.data.datasets[datasetIndex].data[index];
+          const month = chart.data.labels[index];
+          const isSsoUser = datasetIndex === 0; // 0 for SSO Registrations, 1 for Non-SSO Registrations
+          if (value !== 0) {
+            const url = `/${language}/browse/contributors/invited?year=${year}&month=${month}&sso_user=${isSsoUser}`;
+            window.location.href = url;
+          }
+        }
+      },
+    },
+  });
+}
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', onLoad);
+} else {
+  onLoad();
+}

--- a/public/scss/_base.lg.scss
+++ b/public/scss/_base.lg.scss
@@ -85,3 +85,17 @@ body {
     padding-bottom: $i * 0.25rem !important;
   }
 }
+
+.line {
+  fill: none;
+  stroke-width: 2px;
+}
+.sso-line {
+  stroke: steelblue;
+}
+.non-sso-line {
+  stroke: orange;
+}
+.axis-label {
+  font-size: 12px;
+}

--- a/public/vocabulary/action-plans.js
+++ b/public/vocabulary/action-plans.js
@@ -99,6 +99,7 @@ export const vocabulary = {
         all: 'All contributors',
         invited: 'My contributors',
         pinned: 'My teams',
+        metrics: 'Metrics',
       },
     },
     fr: {
@@ -140,6 +141,7 @@ export const vocabulary = {
         all: 'Tou.te.s les contribut.rices.eurs',
         invited: 'Mes contribut.rices.eurs',
         pinned: 'Mes équipes',
+        metrics: 'Métriques',
       },
     },
     es: {
@@ -181,6 +183,7 @@ export const vocabulary = {
         all: 'Tod.a.o.s l.a.o.s contribuyentes',
         invited: 'Mis contribuyentes',
         pinned: 'Mis equipos',
+        metrics: 'Métricas',
       },
     },
     pt: {
@@ -222,6 +225,7 @@ export const vocabulary = {
         all: 'Todos os ontribuidor.e.a.s',
         invited: 'Meus contribuidor.e.a.s',
         pinned: 'Minhas equipes',
+        metrics: 'Métricas',
       },
     },
   },

--- a/public/vocabulary/base.js
+++ b/public/vocabulary/base.js
@@ -99,6 +99,7 @@ export const vocabulary = {
         all: 'All contributors',
         invited: 'My contributors',
         pinned: 'My teams',
+        metrics: 'Metrics',
       },
     },
     fr: {
@@ -140,6 +141,7 @@ export const vocabulary = {
         all: 'Tou.te.s les contribut.rices.eurs',
         invited: 'Mes contribut.rices.eurs',
         pinned: 'Mes équipes',
+        metrics: 'Métriques'
       },
     },
     es: {
@@ -181,6 +183,7 @@ export const vocabulary = {
         all: 'Tod.a.o.s l.a.o.s contribuyentes',
         invited: 'Mis contribuyentes',
         pinned: 'Mis equipos',
+        metrics: 'Métricas'
       },
     },
     pt: {
@@ -222,6 +225,7 @@ export const vocabulary = {
         all: 'Todos os ontribuidor.e.a.s',
         invited: 'Meus contribuidor.e.a.s',
         pinned: 'Minhas equipes',
+        metrics: 'Métricas'
       },
     },
   },

--- a/public/vocabulary/experiments.js
+++ b/public/vocabulary/experiments.js
@@ -99,6 +99,7 @@ export const vocabulary = {
         all: 'All contributors',
         invited: 'My contributors',
         pinned: 'My teams',
+        metrics: 'Metrics'
       },
     },
     fr: {
@@ -140,6 +141,7 @@ export const vocabulary = {
         all: 'Tou.te.s les contribut.rices.eurs',
         invited: 'Mes contribut.rices.eurs',
         pinned: 'Mes équipes',
+        metrics: 'Métriques'
       },
     },
     es: {
@@ -181,6 +183,7 @@ export const vocabulary = {
         all: 'Tod.a.o.s l.a.o.s contribuyentes',
         invited: 'Mis contribuyentes',
         pinned: 'Mis equipos',
+        metrics: 'Métricas',
       },
     },
     pt: {
@@ -222,6 +225,7 @@ export const vocabulary = {
         all: 'Todos os ontribuidor.e.a.s',
         invited: 'Meus contribuidor.e.a.s',
         pinned: 'Minhas equipes',
+        metrics: 'Métricas',
       },
     },
   },

--- a/public/vocabulary/signals.js
+++ b/public/vocabulary/signals.js
@@ -99,6 +99,7 @@ export const vocabulary = {
         all: 'All contributors',
         invited: 'My contributors',
         pinned: 'My teams',
+        metrics: 'Metrics',
       },
     },
     fr: {
@@ -140,6 +141,7 @@ export const vocabulary = {
         all: 'Tou.te.s les contribut.rices.eurs',
         invited: 'Mes contribut.rices.eurs',
         pinned: 'Mes équipes',
+        metrics: 'Métriques',
       },
     },
     es: {
@@ -181,6 +183,7 @@ export const vocabulary = {
         all: 'Tod.a.o.s l.a.o.s contribuyentes',
         invited: 'Mis contribuyentes',
         pinned: 'Mis equipos',
+        metrics: 'Métricas',
       },
     },
     pt: {
@@ -222,6 +225,7 @@ export const vocabulary = {
         all: 'Todos os ontribuidor.e.a.s',
         invited: 'Meus contribuidor.e.a.s',
         pinned: 'Minhas equipes',
+        metrics: 'Métricas',
       },
     },
   },

--- a/public/vocabulary/solutions-mapping.js
+++ b/public/vocabulary/solutions-mapping.js
@@ -99,6 +99,7 @@ export const vocabulary = {
         all: 'All contributors',
         invited: 'My contributors',
         pinned: 'My teams',
+        metrics: 'Metrics',
       },
     },
     fr: {
@@ -140,6 +141,7 @@ export const vocabulary = {
         all: 'Tou.te.s les contribut.rices.eurs',
         invited: 'Mes contribut.rices.eurs',
         pinned: 'Mes équipes',
+        metrics: 'Métriques',
       },
     },
     es: {
@@ -181,6 +183,7 @@ export const vocabulary = {
         all: 'Tod.a.o.s l.a.o.s contribuyentes',
         invited: 'Mis contribuyentes',
         pinned: 'Mis equipos',
+        metrics: 'Métricas',
       },
     },
     pt: {
@@ -222,6 +225,7 @@ export const vocabulary = {
         all: 'Todos os ontribuidor.e.a.s',
         invited: 'Meus contribuidor.e.a.s',
         pinned: 'Minhas equipes',
+        metrics: 'Métricas',
       },
     },
   },

--- a/routes/apis/contributors/index.js
+++ b/routes/apis/contributors/index.js
@@ -1,2 +1,3 @@
 exports.xlsx = require('./xlsx.js')
 exports.json = require('./json.js')
+exports.metrics = require('./metrics.js')

--- a/routes/apis/contributors/metrics.js
+++ b/routes/apis/contributors/metrics.js
@@ -1,0 +1,61 @@
+const { DB } = include('config/')
+module.exports = async (req, res) => {
+	const { year } = req.query;
+    let query, params;
+
+    if (year && +year) {
+        // Query to group by month if a year is provided
+        query = `
+        SELECT
+            to_char(COALESCE(created_at, invited_at), 'Month') as period,
+            SUM(CASE WHEN created_from_sso THEN 1 ELSE 0 END) as sso_count,
+            SUM(CASE WHEN NOT created_from_sso THEN 1 ELSE 0 END) as non_sso_count
+        FROM
+            public.users
+        WHERE
+            EXTRACT(YEAR FROM COALESCE(created_at, invited_at)) = $1
+        GROUP BY
+            to_char(COALESCE(created_at, invited_at), 'Month'),
+            date_trunc('month', COALESCE(created_at, invited_at))
+        ORDER BY
+            date_trunc('month', COALESCE(created_at, invited_at));
+        `;
+        params = [year];
+    } else {
+        // Query to group by year if no year is provided
+        query = `
+        SELECT
+            EXTRACT(YEAR FROM COALESCE(created_at, invited_at)) as period,
+            SUM(CASE WHEN created_from_sso THEN 1 ELSE 0 END) as sso_count,
+            SUM(CASE WHEN NOT created_from_sso THEN 1 ELSE 0 END) as non_sso_count
+        FROM
+            public.users
+        GROUP BY
+            EXTRACT(YEAR FROM COALESCE(created_at, invited_at))
+        ORDER BY
+            EXTRACT(YEAR FROM COALESCE(created_at, invited_at));
+        `;
+        params = [];
+    }
+
+    DB.general.tx(async t=>{
+        const batch = []
+        batch.push(t.any(query, params))
+        batch.push(t.any(`
+            SELECT DISTINCT EXTRACT(YEAR FROM COALESCE(created_at, invited_at)) AS year
+            FROM public.users
+            ORDER BY year;
+        `))
+
+        return t.batch(batch)
+        .catch(err => console.log(err))
+    })
+    .then(result=>{
+        const [ data, years ] = result
+        return res.json({ data, years });
+    })
+    .catch(err => {
+        console.error(err);
+        res.status(500).send('Server Error');
+      })
+}

--- a/routes/apis/index.js
+++ b/routes/apis/index.js
@@ -31,6 +31,7 @@ module.exports = (req, res) => {
 			else redirectError(req, res)
 		} else if (object === 'files') files(req, res)
 		else if (object === 'contributors') contributors.json(req, res)
+		else if (object === 'user-metrics') contributors.metrics(req, res)
 		else if (object === 'tags') tags(req, res)
 		else if (object === 'statistics') statistics(req, res)
 		else if (object === 'countries') locations.countries(req, res)

--- a/routes/browse/contributors/filter.js
+++ b/routes/browse/contributors/filter.js
@@ -39,7 +39,7 @@ module.exports = req => {
 		if (limit === null) content_filters.push(DB.pgp.as.format(`AND TRUE`))
 		else if (typeof limit === 'string' && limit.length === 1) page = limit.toUpperCase()
 		
-		const is_sso_user = sso_user == 'true'
+		const is_sso_user = sso_user === 'true'
 
 		if(+year && month) {
 			content_filters.push(DB.pgp.as.format(`

--- a/routes/browse/contributors/filter.js
+++ b/routes/browse/contributors/filter.js
@@ -3,13 +3,12 @@ const { parsers } = include('routes/helpers/')
 
 module.exports = req => {
 	const { uuid, rights } = req.session || {}
-
 	let { space } = req.params || {}
 	if (!space) space = Object.keys(req.query)?.length ? req.query.space : Object.keys(req.body)?.length ? req.body.space : {} // req.body?.space // THIS IS IN CASE OF POST REQUESTS (e.g. COMMING FROM APIS/ DOWNLOAD)
 	const { limit } = req.body || {} // THIS IS IN THE CASE OF AJAX REQUESTS, TO LIMIT TO A CERTAIN LETTER OR NOT
 
 	// TO DO: UPDATE BELOW BASED ON FILTERS PASSED
-	let { search, status, countries, positions, rights: userrights, pinboard, page } = Object.keys(req.query)?.length ? req.query : Object.keys(req.body)?.length ? req.body : {}
+	let { search, status, countries, positions, rights: userrights, pinboard, page, year, month, sso_user } = Object.keys(req.query)?.length ? req.query : Object.keys(req.body)?.length ? req.body : {}
 
 	return (async () => {
 		// BASE FILTERS
@@ -25,7 +24,7 @@ module.exports = req => {
 		if (space === 'all') f_space = DB.pgp.as.format(`AND (u.rights >= $1::INT)`, [ write ?? 4 ])
 		if (space === 'invited') f_space = DB.pgp.as.format(`AND (u.uuid IN (SELECT contributor FROM cohorts WHERE host = $1) OR $2 > 2)`, [ uuid, rights ])
 		if (f_space) base_filters.push(f_space)
-
+		
 		// PLATFORM FILTERS
 		const platform_filters = []
 		if (countries) platform_filters.push(DB.pgp.as.format(`AND u.iso3 IN ($1:csv)`, [ countries ]))
@@ -39,6 +38,24 @@ module.exports = req => {
 		// BELOW IS FOR AJAX CALLS WITH POST
 		if (limit === null) content_filters.push(DB.pgp.as.format(`AND TRUE`))
 		else if (typeof limit === 'string' && limit.length === 1) page = limit.toUpperCase()
+		
+		const is_sso_user = sso_user == 'true'
+
+		if(+year && month) {
+			content_filters.push(DB.pgp.as.format(`
+				AND 
+				(EXTRACT(YEAR FROM COALESCE(created_at, invited_at)) =$1
+				AND TRIM(TO_CHAR(COALESCE(created_at, invited_at), 'Month')) ILIKE $2)
+				AND created_from_sso = $3
+			`, [ year, month, is_sso_user]))
+		}
+		else if((!year || year == 'undefined') && +month){
+			content_filters.push(DB.pgp.as.format(`
+				AND 
+				(EXTRACT(YEAR FROM COALESCE(created_at, invited_at)) = $1
+				AND created_from_sso = $2)
+			`, [ month, is_sso_user ]))
+		}
 
 		const filters = [ base_filters.join(' '), platform_filters.join(' '), content_filters.join(' ') ].filter(d => d)
 		if (!platform_filters.length && !content_filters.length) {
@@ -52,7 +69,7 @@ module.exports = req => {
 				LIMIT 1
 			;`, [ uuid, rights ], d => d.letter)
 			.catch(err => console.log(err)) || 'A'
-
+			
 			filters.push(DB.pgp.as.format(`AND LEFT(u.name, 1) = $1`, [ page ]))
 		}
 

--- a/routes/helpers/datastructures/index.js
+++ b/routes/helpers/datastructures/index.js
@@ -101,6 +101,7 @@ exports.pagemetadata = (_kwargs) => {
 	path = path.substring(1).split('/')
 	let activity = path[1]
 	const currentpage_url = `${req.protocol}://${req.get('host')}${req.originalUrl}`
+	let add_web_analytics = process.env.NODE_ENV == 'production' && !req.get('host').includes('azurewebsites.net')
 
 	let { object, space, instance } = params || {}
 	if (instance) {
@@ -310,7 +311,8 @@ exports.pagemetadata = (_kwargs) => {
 				app_suite_url,
 				allowsso,
 				login_url: !compareReqDomain(req, currentpage_url, sso_app_url) ? sso_app_url : null,
-				platform_urls
+				platform_urls,
+				add_web_analytics,
 			},
 			user: {
 				uuid,

--- a/routes/login/process.js
+++ b/routes/login/process.js
@@ -159,6 +159,15 @@ module.exports = (req, res, next) => {
 						redirecturl = originalUrl || referer;
 					}
 
+					//UPDATE USER LAST LOGIN INFO
+					t.none(`
+						UPDATE public.users 
+						SET last_login = now() 
+						WHERE uuid = $1`,
+						[ result.uuid]
+					)
+					.catch(err => console.log(err));
+
 					// CHECK IF DEVICE IS TRUSTED
 					return t.oneOrNone(`
 						SELECT * FROM trusted_devices
@@ -174,7 +183,7 @@ module.exports = (req, res, next) => {
 						[result.uuid, device.os, device.browser, device.device, __ucd_app, __puid, __cduid, sid ]
 					).then(async deviceResult => {
 						if (deviceResult) {
-							// Device is trusted, update last login info
+							// Device is trusted, update device last login info
 							return t.none(`
 								UPDATE trusted_devices SET last_login = $1, session_sid = $5
 								WHERE user_uuid = $2

--- a/routes/login/sso-validate.js
+++ b/routes/login/sso-validate.js
@@ -58,8 +58,8 @@ module.exports = (req, res, next) => {
         return t
           .oneOrNone(
             `
-                INSERT INTO users (email, name, rights, position, password, iso3, created_from_sso, confirmed, notifications, confirmed_at)
-                VALUES ($1, $2, $3, $4, crypt($5, GEN_SALT('bf', 8)), $6, TRUE, TRUE, TRUE, NOW())
+                INSERT INTO users (email, name, rights, position, password, iso3, created_from_sso, confirmed, notifications, confirmed_at, last_login)
+                VALUES ($1, $2, $3, $4, crypt($5, GEN_SALT('bf', 8)), $6, TRUE, TRUE, TRUE, NOW(), NOW())
                 ON CONFLICT (email)
                 DO UPDATE SET name = EXCLUDED.name
             ;`,

--- a/views/browse/index.ejs
+++ b/views/browse/index.ejs
@@ -56,7 +56,11 @@
 
 <%- include ('./modules/data.ejs') %>
 
-<script type='module' src='/js/browse/load.js'></script>
+<% if (space == 'metrics') { %>
+	<script type='module' src='/js/browse/chart.js'></script>
+<%} else { %>
+	<script type='module' src='/js/browse/load.js'></script>
+<% } %>
 
 </head>
 
@@ -141,6 +145,10 @@
 
 			<main>
 				<div class='inner'>
+					<% if (space == 'metrics') { %>
+						<div id="metrics"></div>
+					<% } %>
+
 					<!-- MULTI-SESSION ALERT -->
 					<%- include('../partials/sessions-alert') %>
 					<!-- INCLUDE THE BLURB -->

--- a/views/browse/modules/filter.ejs
+++ b/views/browse/modules/filter.ejs
@@ -21,8 +21,9 @@
 		else return num
 	}
 %>
-
-<% if (locals.stats?.total > 0) { %>
+<% if (space == 'metrics') { %>
+	<span></span>
+<% } else if (locals.stats?.total > 0 ) { %>
 	<nav id='search-and-filter' class='xs sm m lg xl xxl<% if (mapscale === "full-screen") { %> anchor-bottom<% } %>'>
 		<% if (false && logged && object === 'pads') { // FIXME reactivate explorations later (and the tabs here) %>
 			<div class="search-type-menu">

--- a/views/browse/modules/tabs.ejs
+++ b/views/browse/modules/tabs.ejs
@@ -102,7 +102,17 @@
 				</button>
 			</a>
 		</li>
-
+		
+		<% if (rights >= 3){ %>
+		<li class='<% if (space === "metrics") { %>active<% } %>'>
+			<a href='./metrics'>
+				<button>
+					<span data-vocab='["space", "<%= object %>", "metrics"]'></span>
+					<div id="metrics-count" class='count'></div>
+				</button>
+			</a>
+		</li>
+		<% } %>
 	<% } else { %>
 		<% if (modules.some(d => {
 			let { write } = d.rights

--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -4,6 +4,7 @@
 	const languages = locals.metadata.site.languages
 	const page_language = locals.metadata.page.page_language
 	const excerpt = locals.metadata.page.excerpt
+	const add_web_analytics = locals.metadata.site.add_web_analytics
 
 	const currentpage_url = new URL(locals.metadata.page.currentpage_url?.replace('/edit/', '/view/'))
 	const currentpage_query = new URLSearchParams(currentpage_url.search)
@@ -85,18 +86,20 @@
 <script type='text/javascript' src='/js/Math.extensions.js'></script>
 <script type='text/javascript' src='/js/Array.prototype.extensions.js'></script>
 <script type='text/javascript' src='/js/Date.prototype.extensions.js'></script>
-<!-- <script type='text/javascript' src='/js/basics.js'></script> -->
 
 <!-- TO DO: MODULARIZE modules.js -->
-<!-- <script type='module' src='/vocabulary/index.js'></script> -->
 <script type='module' src='/js/load.js'></script>
 <script type='module' src='/js/navigate/load.js'></script>
-<!-- <script type='module' src='/js/navigate/gtranslate.js'></script> -->
-<!-- <script type='text/javascript' src='/js/upload.js'></script> -->
 
 <!-- Google Translate CDN -->
 <script type='text/javascript' src="https://translate.google.com/translate_a/element.js?cb=googleTranslateElementInit" nonce="<%- nonce %>"></script>
-<!-- <script src = '/socket.io/socket.io.js'></script> -->
+
+<!-- ADD WEB ANALYTICS SCRIPT -->
+<% if (add_web_analytics) { %>
+	<script data-goatcounter="https://sdg-innovation-commons.goatcounter.com/count" async src="//gc.zgo.at/count.js" nonce="<%- nonce %>" ></script>
+<% } %>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js" nonce="<%- nonce %>" ></script>
 
 <link rel='stylesheet' href='https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined'>
 <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.2.0/css/font-awesome.min.css" rel="stylesheet">


### PR DESCRIPTION
- [x] Add GoatCounter website anaytics to platform. Stats of analytics can be found here: https://sdg-innovation-commons.goatcounter.com/

- [x] Show chart plots of user registration per year/month based on user selction. This will allow ssystem admins to understand how user registers on the platform whether by SSO or invitation. This will allow us know how many people has onboarded the platform using the SSO. 