### PR TITLE
fixed locations for pads api

### DIFF
--- a/routes/apis/pads/json.js
+++ b/routes/apis/pads/json.js
@@ -269,7 +269,10 @@ module.exports = async (req, res) => {
 
 							// SET LOCATIONS
 							if (!include_locations) delete d.locations;
-							else d.locations = await join.locations(d.locations, { language, key: 'iso3' });
+							else {
+								if (d.locations?.length) d.locations = await join.locations(d.locations, { language, key: 'iso3' });
+								else d.locations = await join.locations([{ iso3: d.iso3 }], { language, key: 'iso3' });
+							}
 
 							// SET IMAGES
 							if (include_imgs) {


### PR DESCRIPTION
- [x] add lat, lng information to the locations object in the pads api for cases when the platform does not use locations as a metafield.